### PR TITLE
Ring topology subset support

### DIFF
--- a/ocelli-core/src/main/java/netflix/ocelli/MembershipEvent.java
+++ b/ocelli-core/src/main/java/netflix/ocelli/MembershipEvent.java
@@ -71,4 +71,32 @@ public class MembershipEvent<Client> {
     public String toString() {
         return "HostEvent [" + type + " " + host + "]";
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((host == null) ? 0 : host.hashCode());
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        MembershipEvent other = (MembershipEvent) obj;
+        if (host == null) {
+            if (other.host != null)
+                return false;
+        } else if (!host.equals(other.host))
+            return false;
+        if (type != other.type)
+            return false;
+        return true;
+    }
 }

--- a/ocelli-core/src/main/java/netflix/ocelli/functions/Connectors.java
+++ b/ocelli-core/src/main/java/netflix/ocelli/functions/Connectors.java
@@ -3,7 +3,7 @@ package netflix.ocelli.functions;
 import netflix.ocelli.ClientConnector;
 import rx.Observable;
 
-public class Connectors {
+public abstract class Connectors {
     public static <C> ClientConnector<C> never() {
         return new ClientConnector<C>() {
             @Override

--- a/ocelli-core/src/main/java/netflix/ocelli/functions/Delays.java
+++ b/ocelli-core/src/main/java/netflix/ocelli/functions/Delays.java
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit;
 
 import rx.functions.Func1;
 
-public class Delays {
+public abstract class Delays {
     public static Func1<Integer, Long> fixed(final long delay, final TimeUnit units) {
         return new Func1<Integer, Long>() {
             @Override

--- a/ocelli-core/src/main/java/netflix/ocelli/functions/Failures.java
+++ b/ocelli-core/src/main/java/netflix/ocelli/functions/Failures.java
@@ -3,7 +3,7 @@ package netflix.ocelli.functions;
 import netflix.ocelli.FailureDetectorFactory;
 import rx.Observable;
 
-public class Failures {
+public abstract class Failures {
     public static <C> FailureDetectorFactory<C> never() {
         return new FailureDetectorFactory<C>() {
             @Override

--- a/ocelli-core/src/main/java/netflix/ocelli/functions/Retrys.java
+++ b/ocelli-core/src/main/java/netflix/ocelli/functions/Retrys.java
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeUnit;
 import rx.Observable;
 import rx.functions.Func1;
 
-public class Retrys {
+public abstract class Retrys {
     public static Func1<Observable<? extends Throwable>, Observable<?>> exponentialBackoff(final int maxRetrys, final long timeslice, final TimeUnit units) {
         return new Func1<Observable<? extends Throwable>, Observable<?>>() {
             @Override

--- a/ocelli-core/src/main/java/netflix/ocelli/functions/Topologies.java
+++ b/ocelli-core/src/main/java/netflix/ocelli/functions/Topologies.java
@@ -1,0 +1,20 @@
+package netflix.ocelli.functions;
+
+import netflix.ocelli.topologies.RingTopology;
+import rx.functions.Func1;
+
+/**
+ * Convenience class for creating different topologies that filter clients into 
+ * a specific arrangement that limit the set of clients this instance will communicate
+ * with.
+ * 
+ * @author elandau
+ *
+ */
+public abstract class Topologies {
+
+    public static <T, K extends Comparable<K>> RingTopology<T,K> ring(K id, Func1<T, K> idFunc, Func1<Integer, Integer> countFunc) {
+        return new RingTopology<T, K>(id, idFunc, countFunc);
+    }
+        
+}

--- a/ocelli-core/src/main/java/netflix/ocelli/topologies/RingTopology.java
+++ b/ocelli-core/src/main/java/netflix/ocelli/topologies/RingTopology.java
@@ -1,0 +1,161 @@
+package netflix.ocelli.topologies;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
+
+import netflix.ocelli.MembershipEvent;
+import netflix.ocelli.MembershipEvent.EventType;
+import rx.Observable.Operator;
+import rx.Subscriber;
+import rx.functions.Func1;
+
+/**
+ * The ring topology uses consistent hashing to arrange all hosts in a predictable ring 
+ * topology such that each client instance will be located in a uniformly distributed
+ * fashion around the ring.  The client will then target the next N hosts after it's location.
+ * 
+ * This type of topology ensures that each client instance communicates with a subset of 
+ * hosts in such a manner that the overall load shall be evenly distributed.
+ * 
+ * @author elandau
+ *
+ * @param <T>
+ * @param <K>
+ */
+public class RingTopology<T, K extends Comparable<K>> implements Operator<MembershipEvent<T>, MembershipEvent<T>> {
+    
+    private static class Holder<T, K extends Comparable<K>> implements Comparable<Holder<T, K>>{
+        private final T value;
+        private final K key;
+        
+        Holder(T value, K key) {
+            assert key != null;
+            this.value = value;
+            this.key = key;
+        }
+
+        @Override
+        public int compareTo(Holder<T, K> o) {
+            assert key != null;
+            if (o == null)
+                return 0;
+            return key.compareTo(o.key);
+        }
+        
+        public String toString() {
+            return key.toString();
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((key == null) ? 0 : key.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            Holder other = (Holder) obj;
+            if (key == null) {
+                if (other.key != null)
+                    return false;
+            } else if (!key.equals(other.key))
+                return false;
+            return true;
+        }
+    }
+    
+    private final Func1<T, K> hashFunc;
+    private final Holder<T, K> me;
+    private Func1<Integer, Integer> countFunc;
+    
+    public RingTopology(K key, Func1<T, K> hashFunc, Func1<Integer, Integer> countFunc) {
+        this.hashFunc  = hashFunc;
+        this.countFunc = countFunc;
+        this.me        = new Holder<T, K>(null, key);
+    }
+    
+    @Override
+    public Subscriber<? super MembershipEvent<T>> call(final Subscriber<? super MembershipEvent<T>> subscriber) {
+        return new Subscriber<MembershipEvent<T>>(subscriber) {
+            final ReentrantLock lock = new ReentrantLock();
+            final List<Holder<T, K>> ring = new ArrayList<Holder<T, K>>();
+            
+            Set<Holder<T, K>> members = new HashSet<Holder<T, K>>();
+            
+            {
+                ring.add(me);
+            }
+            
+            @Override
+            public void onCompleted() {
+                subscriber.onCompleted();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                subscriber.onError(e);
+            }
+
+            @Override
+            public void onNext(final MembershipEvent<T> t) {
+                try {
+                    lock.lock();
+                    
+                    // Update the ring
+                    switch (t.getType()) {
+                    case ADD:
+                        ring.add(new Holder<T, K>(t.getClient(), hashFunc.call(t.getClient())));
+                        break;
+                    case REMOVE:
+                        ring.remove(new Holder<T, K>(t.getClient(), hashFunc.call(t.getClient())));
+                        break;
+                    }
+                    
+                    // Re-sort the ring
+                    Collections.sort(ring);
+                    
+                    // -1 to account for 'me'
+                    int count = Math.min(ring.size()-1, countFunc.call(ring.size()-1));
+                    
+                    // Determine the new set of hosts
+                    int pos = Collections.binarySearch(ring, me)+1;
+                    Set<Holder<T, K>> newMembers = new HashSet<Holder<T, K>>();
+                    for (int i = 0; i < count; i++) {
+                        newMembers.add(ring.get((pos + i) % ring.size()));
+                    }
+                    
+                    // Forward 'new' hosts as ADD events
+                    for (Holder<T, K> member : newMembers) {
+                        if (!members.contains(member)) {
+                            subscriber.onNext(MembershipEvent.create(member.value, EventType.ADD));
+                        }
+                    }
+                    
+                    // Forward 'removed' hosts as REMOVE events 
+                    for (final Holder<T, K> member : members) {
+                        if (!newMembers.contains(member)) {
+                            subscriber.onNext(MembershipEvent.create(member.value, EventType.REMOVE));
+                        }
+                    }
+                    
+                    members = newMembers;
+                }
+                finally {
+                    lock.unlock();
+                }
+            }
+        };
+    }
+}

--- a/ocelli-core/src/test/java/netflix/ocelli/functions/TopologiesTest.java
+++ b/ocelli-core/src/test/java/netflix/ocelli/functions/TopologiesTest.java
@@ -1,0 +1,108 @@
+package netflix.ocelli.functions;
+
+import java.util.List;
+
+import junit.framework.Assert;
+import netflix.ocelli.Host;
+import netflix.ocelli.MembershipEvent;
+import netflix.ocelli.MembershipEvent.EventType;
+
+import org.junit.Test;
+
+import rx.Observable;
+import rx.functions.Func1;
+
+import com.google.common.collect.Lists;
+
+public class TopologiesTest {
+    public static class HostWithId extends Host {
+        private final Integer id;
+        
+        public HostWithId(String hostName, int port, Integer id) {
+            super(hostName, port);
+            this.id = id;
+        }
+
+        public Integer getId() {
+            return this.id;
+        }
+        
+        public String toString() {
+            return id.toString();
+        }
+    }
+    
+    @Test
+    public void test() {
+        int me = 81;
+        List<HostWithId> hosts = Lists.newArrayList();
+        
+        HostWithId h1 = new HostWithId("host10", 8080, 10);
+        HostWithId h2 = new HostWithId("host20", 8080, 20);
+        HostWithId h3 = new HostWithId("host30", 8080, 30);
+        HostWithId h4 = new HostWithId("host40", 8080, 40);
+        HostWithId h5 = new HostWithId("host50", 8080, 50);
+        HostWithId h6 = new HostWithId("host60", 8080, 60);
+        HostWithId h7 = new HostWithId("host70", 8080, 70);
+        HostWithId h8 = new HostWithId("host80", 8080, 80);
+        HostWithId h9 = new HostWithId("host90", 8080, 90);
+        HostWithId h10 = new HostWithId("host100", 8080, 100);
+        
+        hosts.add(h5);
+        hosts.add(h7);
+        hosts.add(h1);
+        hosts.add(h2);
+        hosts.add(h4);
+        hosts.add(h3);
+        hosts.add(h8);
+        hosts.add(h10);
+        hosts.add(h9);
+        hosts.add(h6);
+        
+        final List<MembershipEvent<HostWithId>> actual = Observable
+            .from(hosts)
+            .map(MembershipEvent.<HostWithId>toEvent(EventType.ADD))
+            .concatWith(Observable.from(Lists.reverse(hosts)).map(MembershipEvent.<HostWithId>toEvent(EventType.REMOVE)))
+            .lift(Topologies.ring(
+                me,
+                new Func1<HostWithId, Integer>() {
+                    @Override
+                    public Integer call(HostWithId t1) {
+                        return t1.id;
+                    }
+                },
+                new Func1<Integer, Integer>() {
+                    @Override
+                    public Integer call(Integer t1) {
+                        return 2;
+                    }
+                }))
+            .toList().toBlocking().first();
+        
+        List<MembershipEvent<HostWithId>> expected = Lists.newArrayList(
+                MembershipEvent.create(h5, EventType.ADD),
+                MembershipEvent.create(h7, EventType.ADD),
+                MembershipEvent.create(h1, EventType.ADD),
+                MembershipEvent.create(h7, EventType.REMOVE),
+                MembershipEvent.create(h2, EventType.ADD),
+                MembershipEvent.create(h5, EventType.REMOVE),
+                MembershipEvent.create(h10, EventType.ADD),
+                MembershipEvent.create(h2, EventType.REMOVE),
+                MembershipEvent.create(h9, EventType.ADD),
+                MembershipEvent.create(h1, EventType.REMOVE),
+
+                MembershipEvent.create(h1, EventType.ADD),
+                MembershipEvent.create(h9, EventType.REMOVE),
+                MembershipEvent.create(h2, EventType.ADD),
+                MembershipEvent.create(h10, EventType.REMOVE),
+                MembershipEvent.create(h5, EventType.ADD),
+                MembershipEvent.create(h2, EventType.REMOVE),
+                MembershipEvent.create(h7, EventType.ADD),
+                MembershipEvent.create(h1, EventType.REMOVE),
+                MembershipEvent.create(h7, EventType.REMOVE),
+                MembershipEvent.create(h5, EventType.REMOVE)
+                );
+        
+        Assert.assertEquals(actual, expected);
+    }
+}


### PR DESCRIPTION
Add support for consistent hashing in a ring topology to evenly distribute client load when restricting the number of target hosts a client communicates with.
