### PR TITLE
Fixing tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,8 @@ plugins {
 
 ext.githubProjectName = rootProject.name
 
-subprojects {
+configure(subprojects) {
+
     apply plugin: 'nebula.netflixoss'
     apply plugin: 'java'
     apply plugin: 'nebula.provided-base'
@@ -35,6 +36,17 @@ subprojects {
     }
 
     group = "com.netflix.ocelli"
+
+    dependencies {
+
+        compile 'io.reactivex:rxjava:1.0.+'
+        compile 'org.slf4j:slf4j-api:1.7.2'
+
+        testCompile 'org.slf4j:slf4j-log4j12:1.7.2'
+        testCompile 'junit:junit:4.12'
+        testCompile "org.hamcrest:hamcrest-library:1.3"
+        testCompile "org.mockito:mockito-core:1.+"
+    }
 
     eclipse {
         classpath {

--- a/ocelli-core/build.gradle
+++ b/ocelli-core/build.gradle
@@ -13,21 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-apply plugin: 'osgi'
-apply plugin: 'groovy'
 
 dependencies {
-    compile 'io.reactivex:rxjava:1.0.12'
-    compile 'org.slf4j:slf4j-api:1.7.2'
-
-    testCompile 'org.slf4j:slf4j-log4j12:1.7.2'
     testCompile 'com.google.guava:guava:14.0.1'
-    testCompile 'junit:junit:4.12'
-}
-
-eclipse {
-    classpath {
-        downloadSources = true
-        downloadJavadoc = true
-    }
 }

--- a/ocelli-core/src/main/java/netflix/ocelli/LoadBalancer.java
+++ b/ocelli-core/src/main/java/netflix/ocelli/LoadBalancer.java
@@ -1,10 +1,5 @@
 package netflix.ocelli;
 
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-
 import netflix.ocelli.InstanceQuarantiner.IncarnationFactory;
 import netflix.ocelli.loadbalancer.RoundRobinLoadBalancer;
 import rx.Observable;
@@ -17,6 +12,11 @@ import rx.functions.Action1;
 import rx.functions.Func1;
 import rx.schedulers.Schedulers;
 import rx.subscriptions.Subscriptions;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * The LoadBalancer tracks lifecycle of entities and selects the next best entity based on plugable 
@@ -112,6 +112,15 @@ public class LoadBalancer<T> {
          */
         public LoadBalancer<T> build(LoadBalancerStrategy<T> strategy) {
             return new LoadBalancer<T>(source.compose(InstanceCollector.<T>create()), strategy);
+        }
+
+        /**
+         * Finally create a load balancer given a specified strategy such as RoundRobin or ChoiceOfTwo
+         * @param strategy
+         * @return
+         */
+        public LoadBalancer<T> build(LoadBalancerStrategy<T> strategy, InstanceCollector<T> instanceCollector) {
+            return new LoadBalancer<T>(source.compose(instanceCollector), strategy);
         }
     }
     

--- a/ocelli-core/src/main/java/netflix/ocelli/loadbalancer/RoundRobinLoadBalancer.java
+++ b/ocelli-core/src/main/java/netflix/ocelli/loadbalancer/RoundRobinLoadBalancer.java
@@ -1,19 +1,17 @@
 package netflix.ocelli.loadbalancer;
 
+import netflix.ocelli.LoadBalancerStrategy;
+
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import netflix.ocelli.LoadBalancerStrategy;
 
 /**
  * Very simple LoadBlancer that when subscribed to gets an ImmutableList of active clients 
  * and round robins on the elements in that list
  * 
  * @author elandau
- *
- * @param <Client>
  */
 public class RoundRobinLoadBalancer<T> implements LoadBalancerStrategy<T> {
     public static <T> RoundRobinLoadBalancer<T> create() {
@@ -27,27 +25,23 @@ public class RoundRobinLoadBalancer<T> implements LoadBalancerStrategy<T> {
     private final AtomicInteger position;
 
     public RoundRobinLoadBalancer() {
-        this.position = new AtomicInteger(new Random().nextInt(1000));
+        position = new AtomicInteger(new Random().nextInt(1000));
     }
     
     public RoundRobinLoadBalancer(int seedPosition) {
-        this.position = new AtomicInteger(seedPosition);
+        position = new AtomicInteger(seedPosition);
     }
 
+    /**
+     * @throws NoSuchElementException
+     */
     @Override
-    public T choose(List<T> local) throws NoSuchElementException {
+    public T choose(List<T> local) {
         if (local.isEmpty()) {
             throw new NoSuchElementException("No servers available in the load balancer");
         }
         else {
-            int pos = position.incrementAndGet();
-            while (pos < 0) {
-                if (position.compareAndSet(pos, 0)) {
-                    pos = 0;
-                    break;
-                }
-                pos = position.incrementAndGet();
-            }
+            int pos = Math.abs(position.incrementAndGet());
             return local.get(pos % local.size());
         }
     }

--- a/ocelli-core/src/test/java/netflix/ocelli/LoadBalancerTest.java
+++ b/ocelli-core/src/test/java/netflix/ocelli/LoadBalancerTest.java
@@ -1,52 +1,35 @@
 package netflix.ocelli;
 
-import java.util.Comparator;
-import java.util.concurrent.TimeUnit;
-
+import com.google.common.collect.Lists;
 import netflix.ocelli.InstanceQuarantiner.IncarnationFactory;
 import netflix.ocelli.functions.Delays;
 import netflix.ocelli.loadbalancer.ChoiceOfTwoLoadBalancer;
 import netflix.ocelli.loadbalancer.RoundRobinLoadBalancer;
-
-import org.junit.Assert;
+import org.hamcrest.MatcherAssert;
 import org.junit.Test;
-
 import rx.Observable;
+import rx.Subscription;
+import rx.functions.Func0;
 import rx.functions.Func1;
 import rx.schedulers.TestScheduler;
 
-import com.google.common.collect.Lists;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.*;
 
 public class LoadBalancerTest {
-    @Test
-    public void createFromFixedList() {
-        LoadBalancer<String> lb = LoadBalancer
-            .fromFixedSource(Lists.newArrayList("host1:8080", "host2:8080"))
-            .build(RoundRobinLoadBalancer.<String>create(0))
-            ;
-        
-        Assert.assertEquals("host1:8080", lb.next());
-        Assert.assertEquals("host2:8080", lb.next());
-    }
-    
-    class ClientWithWeight {
-        private String address;
-        private Integer weight;
-        
-        public ClientWithWeight(String address, int weight) {
-            this.address = address;
-            this.weight = weight;
-        }
-    }
-    
-    Comparator<ClientWithWeight> COMPARE_BY_WEIGHT = new Comparator<ClientWithWeight>() {
+
+    private static final Comparator<ClientWithWeight> COMPARE_BY_WEIGHT = new Comparator<ClientWithWeight>() {
         @Override
         public int compare(ClientWithWeight o1, ClientWithWeight o2) {
             return o1.weight.compareTo(o2.weight);
         }
     };
 
-    Func1<Instance<String>, Instance<ClientWithWeight>> CLIENT_FROM_ADDRESS = new Func1<Instance<String>, Instance<ClientWithWeight>>() {
+    private static final Func1<Instance<String>, Instance<ClientWithWeight>> CLIENT_FROM_ADDRESS = new Func1<Instance<String>, Instance<ClientWithWeight>>() {
         @Override
         public Instance<ClientWithWeight> call(Instance<String> t1) {
             return Instance.create(new ClientWithWeight(t1.getValue(), 1), t1.getLifecycle());
@@ -54,39 +37,100 @@ public class LoadBalancerTest {
     };
 
     @Test
+    public void createFromFixedList() {
+        LoadBalancer<String> lb = LoadBalancer
+                .fromFixedSource(Lists.newArrayList("host1:8080", "host2:8080"))
+                .build(RoundRobinLoadBalancer.<String>create(0),
+                       InstanceCollector.create(new Func0<Map<String, Subscription>>() {
+                           @Override
+                           public Map<String, Subscription> call() {
+                               return new LinkedHashMap<String, Subscription>();
+                           }
+                       }))
+                ;
+
+        MatcherAssert.assertThat("Unexpected first host chosen.", lb.next(), is("host2:8080"));
+        MatcherAssert.assertThat("Unexpected second host chosen.", lb.next(), is("host1:8080"));
+    }
+
+    @Test
     public void createFromFixedListAndConvertToDifferentType() {
         LoadBalancer<ClientWithWeight> lb = LoadBalancer
             .fromFixedSource(Lists.newArrayList("host1:8080", "host2:8080"))
             .convertTo(CLIENT_FROM_ADDRESS)
-            .build(RoundRobinLoadBalancer.<ClientWithWeight>create(0))
+            .build(RoundRobinLoadBalancer.<ClientWithWeight>create(0),
+                   InstanceCollector.create(new Func0<Map<ClientWithWeight, Subscription>>() {
+                        @Override
+                        public Map<ClientWithWeight, Subscription> call() {
+                            return new LinkedHashMap<ClientWithWeight, Subscription>();
+                        }
+                    }))
             ;
-        
-        Assert.assertEquals("host2:8080", lb.next().address);
-        Assert.assertEquals("host1:8080", lb.next().address);
+
+        MatcherAssert.assertThat("Unexpected first host chosen.", lb.next().address, equalTo("host2:8080"));
+        MatcherAssert.assertThat("Unexpected second host chosen.", lb.next().address, equalTo("host1:8080"));
     }
     
     @Test
     public void createFromFixedListWithAdvancedAlgorithm() {
         LoadBalancer<ClientWithWeight> lb = LoadBalancer
-            .fromFixedSource(Lists.newArrayList(new ClientWithWeight("host1:8080", 1), new ClientWithWeight("host2:8080", 2)))
-            .build(ChoiceOfTwoLoadBalancer.<ClientWithWeight>create(COMPARE_BY_WEIGHT))
+            .fromFixedSource(
+                    Lists.newArrayList(new ClientWithWeight("host1:8080", 1), new ClientWithWeight("host2:8080", 2)))
+            .build(ChoiceOfTwoLoadBalancer.create(COMPARE_BY_WEIGHT),
+                   InstanceCollector.create(new Func0<Map<ClientWithWeight, Subscription>>() {
+                       @Override
+                       public Map<ClientWithWeight, Subscription> call() {
+                           return new LinkedHashMap<ClientWithWeight, Subscription>();
+                       }
+                   }))
             ;
-            
-        Assert.assertEquals("host2:8080", lb.next().address);
-        Assert.assertEquals("host2:8080", lb.next().address);
+
+        MatcherAssert.assertThat("Unexpected first host chosen.", lb.next().address, equalTo("host2:8080"));
+        MatcherAssert.assertThat("Unexpected second host chosen.", lb.next().address, equalTo("host2:8080"));
     }
-    
-    class ClientWithLifecycle {
-        private String address;
-        private InstanceEventListener listener;
+
+    @Test
+    public void createFromFixedAndUseQuaratiner() {
+        TestScheduler scheduler = new TestScheduler();
+
+        LoadBalancer<ClientWithLifecycle> lb = LoadBalancer
+                .fromFixedSource(Lists.newArrayList(new ClientWithLifecycle("host1:8080"),
+                                                    new ClientWithLifecycle("host2:8080")))
+                .withQuarantiner(new IncarnationFactory<ClientWithLifecycle>() {
+                    @Override
+                    public ClientWithLifecycle create(ClientWithLifecycle client,
+                                                      InstanceEventListener listener,
+                                                      Observable<Void> lifecycle) {
+                        return new ClientWithLifecycle(client, listener);
+                    }
+                }, Delays.fixed(10, TimeUnit.SECONDS), scheduler)
+                .build(RoundRobinLoadBalancer.<ClientWithLifecycle>create(0),
+                       InstanceCollector.create(new Func0<Map<ClientWithLifecycle, Subscription>>() {
+                           @Override
+                           public Map<ClientWithLifecycle, Subscription> call() {
+                               return new LinkedHashMap<ClientWithLifecycle, Subscription>();
+                           }
+                       }));
+
+        ClientWithLifecycle clientToFail = lb.next();
+        MatcherAssert.assertThat("Unexpected host chosen before failure.", clientToFail.address, equalTo("host2:8080"));
+        clientToFail.forceFail();
+
+        MatcherAssert.assertThat("Unexpected first host chosen post failure.", lb.next().address, equalTo("host1:8080"));
+        MatcherAssert.assertThat("Unexpected second host chosen post failure.", lb.next().address, equalTo("host1:8080"));
+    }
+
+    static class ClientWithLifecycle {
+        private final String address;
+        private final InstanceEventListener listener;
         
         public ClientWithLifecycle(String address) {
             this.address = address;
-            this.listener = null;
+            listener = null;
         }
         
         public ClientWithLifecycle(ClientWithLifecycle parent, InstanceEventListener listener) {
-            this.address  = parent.address;
+            address = parent.address;
             this.listener = listener;
         }
         
@@ -94,30 +138,15 @@ public class LoadBalancerTest {
             listener.onEvent(InstanceEvent.EXECUTION_FAILED, 0, TimeUnit.MILLISECONDS, new Throwable("Failed"), null);
         }
     }
-    
 
-    @Test
-    public void createFromFixedAndUseQuaratiner() {
-        TestScheduler scheduler = new TestScheduler();
-        
-        LoadBalancer<ClientWithLifecycle> lb = LoadBalancer
-                .fromFixedSource(Lists.newArrayList(new ClientWithLifecycle("host1:8080"), new ClientWithLifecycle("host2:8080")))
-                .withQuarantiner(new IncarnationFactory<ClientWithLifecycle>() {
-                    @Override
-                    public ClientWithLifecycle create(ClientWithLifecycle client,
-                            InstanceEventListener listener,
-                            Observable<Void> lifecycle) {
-                        return new ClientWithLifecycle(client, listener);
-                    }
-                }, Delays.fixed(10, TimeUnit.SECONDS), scheduler)
-                .build(RoundRobinLoadBalancer.<ClientWithLifecycle>create(0));
-        
-        ClientWithLifecycle clientToFail = lb.next();
-        Assert.assertEquals("host2:8080", clientToFail.address);
-        clientToFail.forceFail();
-        
-        Assert.assertEquals("host1:8080", lb.next().address);
-        Assert.assertEquals("host1:8080", lb.next().address);
 
+    static class ClientWithWeight {
+        private final String address;
+        private final Integer weight;
+
+        public ClientWithWeight(String address, int weight) {
+            this.address = address;
+            this.weight = weight;
+        }
     }
 }

--- a/ocelli-core/src/test/java/netflix/ocelli/loadbalancer/ChoiceOfTwoLoadBalancerTest.java
+++ b/ocelli-core/src/test/java/netflix/ocelli/loadbalancer/ChoiceOfTwoLoadBalancerTest.java
@@ -1,26 +1,23 @@
 package netflix.ocelli.loadbalancer;
 
+import com.google.common.collect.Lists;
+import netflix.ocelli.LoadBalancer;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import rx.subjects.BehaviorSubject;
+
 import java.util.Comparator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 
-import junit.framework.Assert;
-import netflix.ocelli.LoadBalancer;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
-
-import rx.subjects.BehaviorSubject;
-
-import com.google.common.collect.Lists;
-
 public class ChoiceOfTwoLoadBalancerTest {
     @Rule
     public TestName name = new TestName();
         
-    private static Comparator<Integer> COMPARATOR = new Comparator<Integer>() {
+    private static final Comparator<Integer> COMPARATOR = new Comparator<Integer>() {
         @Override
         public int compare(Integer o1, Integer o2) {
             return o1 - o2;

--- a/ocelli-core/src/test/java/netflix/ocelli/loadbalancer/weighting/InverseMaxWeightingStrategyTest.java
+++ b/ocelli-core/src/test/java/netflix/ocelli/loadbalancer/weighting/InverseMaxWeightingStrategyTest.java
@@ -1,21 +1,18 @@
 package netflix.ocelli.loadbalancer.weighting;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.NoSuchElementException;
-
-import junit.framework.Assert;
+import com.google.common.collect.Lists;
 import netflix.ocelli.LoadBalancer;
 import netflix.ocelli.loadbalancer.RandomWeightedLoadBalancer;
 import netflix.ocelli.retry.RetryFailedTestRule;
 import netflix.ocelli.retry.RetryFailedTestRule.Retry;
-
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-
 import rx.subjects.BehaviorSubject;
 
-import com.google.common.collect.Lists;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
 
 public class InverseMaxWeightingStrategyTest extends BaseWeightingStrategyTest {
     @Rule

--- a/ocelli-core/src/test/java/netflix/ocelli/loadbalancer/weighting/LinearWeightingStrategyTest.java
+++ b/ocelli-core/src/test/java/netflix/ocelli/loadbalancer/weighting/LinearWeightingStrategyTest.java
@@ -1,21 +1,18 @@
 package netflix.ocelli.loadbalancer.weighting;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.NoSuchElementException;
-
-import junit.framework.Assert;
+import com.google.common.collect.Lists;
 import netflix.ocelli.LoadBalancer;
 import netflix.ocelli.loadbalancer.RandomWeightedLoadBalancer;
 import netflix.ocelli.retry.RetryFailedTestRule;
 import netflix.ocelli.retry.RetryFailedTestRule.Retry;
-
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-
 import rx.subjects.BehaviorSubject;
 
-import com.google.common.collect.Lists;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
 
 public class LinearWeightingStrategyTest extends BaseWeightingStrategyTest {
                 

--- a/ocelli-core/src/test/java/netflix/ocelli/toplogies/TopologiesTest.java
+++ b/ocelli-core/src/test/java/netflix/ocelli/toplogies/TopologiesTest.java
@@ -1,9 +1,6 @@
 package netflix.ocelli.toplogies;
 
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-
-import junit.framework.Assert;
+import com.google.common.collect.Sets;
 import netflix.ocelli.CloseableInstance;
 import netflix.ocelli.Host;
 import netflix.ocelli.Instance;
@@ -11,13 +8,13 @@ import netflix.ocelli.InstanceCollector;
 import netflix.ocelli.functions.Functions;
 import netflix.ocelli.topologies.RingTopology;
 import netflix.ocelli.util.RxUtil;
-
+import org.junit.Assert;
 import org.junit.Test;
-
 import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
 
-import com.google.common.collect.Sets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class TopologiesTest {
     public static class HostWithId extends Host {
@@ -61,7 +58,7 @@ public class TopologiesTest {
         members
                .doOnNext(RxUtil.info("add"))
                .compose(mapper)
-               .compose(new InstanceCollector<Integer>())
+               .compose(InstanceCollector.<Integer>create())
                .doOnNext(RxUtil.info("current"))
                .subscribe(RxUtil.set(current));
                

--- a/ocelli-eureka/build.gradle
+++ b/ocelli-eureka/build.gradle
@@ -13,14 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-apply plugin: 'osgi'
-apply plugin: 'groovy'
-
 dependencies {
     compile project(':ocelli-core')
     compile 'com.netflix.eureka:eureka-client:1.1.159'
-
-    testCompile 'org.mockito:mockito-core:1.9.5'
-    testCompile 'junit:junit:4.10'
 }

--- a/ocelli-eureka2/build.gradle
+++ b/ocelli-eureka2/build.gradle
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-apply plugin: 'osgi'
-apply plugin: 'groovy'
-
 dependencies {
     compile project(':ocelli-core')
     compile 'com.netflix.eureka:eureka2-client:2.0.0-rc.2'
-
-    testCompile 'org.mockito:mockito-core:1.9.5'
-    testCompile 'junit:junit:4.10'
 }

--- a/ocelli-examples/build.gradle
+++ b/ocelli-examples/build.gradle
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-apply plugin: 'osgi'
-apply plugin: 'groovy'
-
 // examples are in Java 8 while rest of projects is Java 7
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8

--- a/ocelli-rxnetty/build.gradle
+++ b/ocelli-rxnetty/build.gradle
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-apply plugin: 'osgi'
-apply plugin: 'groovy'
-
 dependencies {
     compile project(':ocelli-core')
     compile 'io.reactivex:rxnetty:0.5.0-SNAPSHOT'

--- a/ocelli-rxnetty/src/test/java/netflix/ocelli/rxnetty/internal/AbstractLoadBalancerTest.java
+++ b/ocelli-rxnetty/src/test/java/netflix/ocelli/rxnetty/internal/AbstractLoadBalancerTest.java
@@ -2,6 +2,7 @@ package netflix.ocelli.rxnetty.internal;
 
 import io.reactivex.netty.protocol.tcp.client.ConnectionFactory;
 import io.reactivex.netty.protocol.tcp.client.ConnectionObservable;
+import io.reactivex.netty.protocol.tcp.client.ConnectionProvider;
 import netflix.ocelli.Instance;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,13 +21,18 @@ public class AbstractLoadBalancerTest {
         List<Instance<SocketAddress>> hosts = lbRule.setupDefault();
         AbstractLoadBalancer<String, String> loadBalancer = lbRule.getLoadBalancer();
         ConnectionFactory<String, String> cfMock = lbRule.newConnectionFactoryMock();
-        ConnectionObservable<String, String> co = loadBalancer.toConnectionProvider(cfMock).nextConnection();
+        ConnectionProvider<String, String> cp = loadBalancer.toConnectionProvider(cfMock);
+        lbRule.startConnectionProvider(cp);
+
+        ConnectionObservable<String, String> co = cp.nextConnection();
 
         lbRule.connect(co);
         Mockito.verify(cfMock).newConnection(hosts.get(0).getValue());
         Mockito.verifyNoMoreInteractions(cfMock);
 
-        co = loadBalancer.toConnectionProvider(cfMock).nextConnection();
+        cp = loadBalancer.toConnectionProvider(cfMock);
+        lbRule.startConnectionProvider(cp);
+        co = cp.nextConnection();
         lbRule.connect(co);
         Mockito.verify(cfMock).newConnection(hosts.get(1).getValue());
         Mockito.verifyNoMoreInteractions(cfMock);

--- a/ocelli-rxnetty/src/test/java/netflix/ocelli/rxnetty/internal/LoadBalancerRule.java
+++ b/ocelli-rxnetty/src/test/java/netflix/ocelli/rxnetty/internal/LoadBalancerRule.java
@@ -206,6 +206,13 @@ public class LoadBalancerRule extends ExternalResource {
         return cfMock;
     }
 
+    public void startConnectionProvider(ConnectionProvider<String, String> cp) {
+        TestSubscriber<Void> startSub = new TestSubscriber<>();
+        cp.start().subscribe(startSub);
+        startSub.awaitTerminalEvent();
+        startSub.assertNoErrors();
+    }
+
     private static class DummyInstance extends Instance<SocketAddress> {
 
         private final SocketAddress socketAddress;

--- a/ocelli-rxnetty/src/test/java/netflix/ocelli/rxnetty/internal/LoadBalancingProviderTest.java
+++ b/ocelli-rxnetty/src/test/java/netflix/ocelli/rxnetty/internal/LoadBalancingProviderTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.mockito.verification.VerificationMode;
 import rx.Observable;
 import rx.functions.Func1;
+import rx.observers.TestSubscriber;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -40,7 +41,7 @@ public class LoadBalancingProviderTest {
         Observable<Instance<ConnectionProvider<String, String>>> providers =
                 loadBalancerRule.getHostsAsConnectionProviders(cfMock);
 
-        LoadBalancingProvider lbProvider = loadBalancer.new LoadBalancingProvider(cfMock, providers);
+        LoadBalancingProvider lbProvider = newLoadBalancingProvider(loadBalancer, cfMock, providers);
 
         @SuppressWarnings("unchecked")
         ConnectionObservable<String, String> connectionObservable = lbProvider.nextConnection();
@@ -76,7 +77,7 @@ public class LoadBalancingProviderTest {
         Observable<Instance<ConnectionProvider<String, String>>> providers =
                 loadBalancerRule.getHostsAsConnectionProviders(cfMock);
 
-        LoadBalancingProvider lbProvider = loadBalancer.new LoadBalancingProvider(cfMock, providers);
+        LoadBalancingProvider lbProvider = newLoadBalancingProvider(loadBalancer, cfMock, providers);
 
         @SuppressWarnings("unchecked")
         ConnectionObservable<String, String> connectionObservable = lbProvider.nextConnection();
@@ -94,5 +95,18 @@ public class LoadBalancingProviderTest {
         Connection<String, String> c = loadBalancerRule.connect(connectionObservable);
         verify(cfMock, verificationMode).newConnection(host);
         return c;
+    }
+
+    protected LoadBalancingProvider newLoadBalancingProvider(AbstractLoadBalancer<String, String> loadBalancer,
+                                                             ConnectionFactory<String, String> cfMock,
+                                                             Observable<Instance<ConnectionProvider<String, String>>> providers) {
+        LoadBalancingProvider lbProvider = loadBalancer.new LoadBalancingProvider(cfMock, providers);
+        TestSubscriber<Void> subscriber = new TestSubscriber<>();
+        @SuppressWarnings("unchecked")
+        Observable<Void> start = lbProvider.start();
+        start.subscribe(subscriber);
+        subscriber.awaitTerminalEvent();
+        subscriber.assertNoErrors();
+        return lbProvider;
     }
 }


### PR DESCRIPTION
Some tests were flaky because of the order of instances emitted by `InstanceCollector` was not deterministic (Used `map.keyset()` on a `ConcurrentHashMap`).
Provided a way to manipulate the map instance used, although error prone (since the map has to be concurrent), at this point, this was the easiest way out. The actual RxNetty module load balancer does not use this collector.

The RxNetty tests were broken with the new snapshot, the `ConnectionProvider` requires an explicit `start()`