### PR TITLE
SnapshotToInstance leaked internal state.

### DIFF
--- a/ocelli-core/src/main/java/netflix/ocelli/LoadBalancer.java
+++ b/ocelli-core/src/main/java/netflix/ocelli/LoadBalancer.java
@@ -152,17 +152,6 @@ public class LoadBalancer<T> {
     }
     
     /**
-     * Construct a load balancer builder from a stream of client snapshots providing
-     * a custom function to extract the cache key from the type.
-     * 
-     * @param source
-     * @return
-     */
-    public static <T> Builder<T> fromSnapshotSource(Observable<List<T>> source, final Func1<T, ?> keyFunc) {
-        return new Builder<T>(source.compose(new SnapshotToInstance<T>(keyFunc)));
-    }
-    
-    /**
      * Construct a load balancer builder from a fixed list of clients
      * @param clients
      * @return

--- a/ocelli-core/src/main/java/netflix/ocelli/SnapshotToInstance.java
+++ b/ocelli-core/src/main/java/netflix/ocelli/SnapshotToInstance.java
@@ -1,16 +1,17 @@
 package netflix.ocelli;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-
 import rx.Observable;
 import rx.Observable.Transformer;
 import rx.functions.Func1;
 import rx.functions.Func2;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Utility class to convert a full snapshot of pool members, T, to an Observable<Instance<T>>
@@ -19,116 +20,56 @@ import rx.functions.Func2;
  * 
  * @author elandau
  *
- * @param <K>
  * @param <T>
  */
 public class SnapshotToInstance<T> implements Transformer<List<T>, Instance<T>> {
-    
-    private static <T> Func1<T, Integer> createDefaultHashCode() { 
-        return new Func1<T, Integer>() {
-            @Override
-            public Integer call(T t1) {
-                return t1.hashCode();
-            }
-        };
-    }
-    
-    private static <T> Func2<T, T, Boolean> createDefaultEquals() { 
-        return new Func2<T, T, Boolean>() {
-            @Override
-            public Boolean call(T t1, T t2) {
-                return (boolean)t1.equals(t2);
-            }
-        };
-    }
-    
-    
-    private final Func1<T, Integer> hashFunc;
-    private final Func2<T, T, Boolean> equalsFunc;
 
-    public SnapshotToInstance() {
-        this(SnapshotToInstance.<T>createDefaultHashCode(), SnapshotToInstance.<T>createDefaultEquals());
-    }
-    
-    public SnapshotToInstance(Func1<T, Integer> hashFunc, Func2<T, T, Boolean> equalsFunc) {
-        this.hashFunc = hashFunc;
-        this.equalsFunc = equalsFunc;
-    }
-    
-    public SnapshotToInstance(final Func1<T, ?> keyFunc) {
-        this.hashFunc = new Func1<T, Integer>() {
-            @Override
-            public Integer call(T t1) {
-                return keyFunc.call(t1).hashCode();
-            }
-        };
-        this.equalsFunc = new Func2<T, T, Boolean>() {
-            @Override
-            public Boolean call(T t1, T t2) {
-                return keyFunc.call(t1).equals(t2);
-            }
-        };
-    }
-    
-    public class TKey {
-        private final T obj;
-
-        public TKey(T obj) {
-            this.obj = obj;
-        }
-        
-        public int hashCode() {
-            return hashFunc.call(obj);
-        }
-        
-        @SuppressWarnings("unchecked")
-        @Override
-        public boolean equals(Object other) {
-            if (this == other)
-                return true;
-            if (other == null)
-                return false;
-            if (getClass() != other.getClass())
-                return false;
-            return equalsFunc.call(obj, ((TKey)other).obj);
-        }
-    }
-    
     public class State {
-        final Map<TKey, CloseableInstance<T>> members = new HashMap<TKey, CloseableInstance<T>>();
-        List<Instance<T>> newInstances = Collections.emptyList();
+        final Map<T, CloseableInstance<T>> members;
+        final List<Instance<T>> newInstances;
+
+        public State() {
+            members = new HashMap<T, CloseableInstance<T>>();
+            newInstances = Collections.emptyList();
+        }
+
+        public State(State toCopy) {
+            members = new HashMap<T, CloseableInstance<T>>(toCopy.members);
+            newInstances = new ArrayList<>();
+        }
     }
     
     @Override
     public Observable<Instance<T>> call(Observable<List<T>> snapshots) {
-        return snapshots
-            .scan(new State(), new Func2<State, List<T>, State>() {
-                @Override
-                public State call(State state, List<T> instances) {
-                    Map<TKey, CloseableInstance<T>> toRemove = new HashMap<TKey, CloseableInstance<T>>(state.members);
-                    state.newInstances = new ArrayList<Instance<T>>();
-                    
-                    for (T ii : instances) {
-                        toRemove.remove(ii);
-                        if (!state.members.containsKey(ii)) {
-                            CloseableInstance<T> member = CloseableInstance.from(ii);
-                            state.members.put(new TKey(ii), member);
-                            state.newInstances.add(member);
-                        }
+        return snapshots.scan(new State(), new Func2<State, List<T>, State>() {
+            @Override
+            public State call(State state, List<T> instances) {
+                State newState = new State(state);
+                Set<T> keysToRemove = new HashSet<T>(newState.members.keySet());
+
+                for (T ii : instances) {
+                    keysToRemove.remove(ii);
+                    if (!newState.members.containsKey(ii)) {
+                        CloseableInstance<T> member = CloseableInstance.from(ii);
+                        newState.members.put(ii, member);
+                        newState.newInstances.add(member);
                     }
-                    
-                    for (Entry<TKey, CloseableInstance<T>> member : toRemove.entrySet()) {
-                        state.members.remove(member.getKey());
-                        member.getValue().close();
+                }
+
+                for (T tKey : keysToRemove) {
+                    CloseableInstance<T> removed = newState.members.remove(tKey);
+                    if (null != removed) {
+                        removed.close();
                     }
-                    return state;
                 }
-            })
-            .concatMap(new Func1<State, Observable<Instance<T>>>() {
-                @Override
-                public Observable<Instance<T>> call(State state) {
-                    return Observable.from(state.newInstances);
-                }
-            });
+
+                return newState;
+            }
+        }).concatMap(new Func1<State, Observable<Instance<T>>>() {
+            @Override
+            public Observable<Instance<T>> call(State state) {
+                return Observable.from(state.newInstances);
+            }
+        });
     }
 }


### PR DESCRIPTION
Internal state Object was emitted from `scan` function which would result in concurrent access to the state object.